### PR TITLE
Installer installs obsolete package

### DIFF
--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -3,7 +3,7 @@
   action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
   with_items:
     - cockpit-ws
-    - cockpit-shell
+    - cockpit-system
     - cockpit-bridge
     - cockpit-docker
     - "{{ cockpit_plugins }}"


### PR DESCRIPTION
Installer installs obsolete packages and gives below error :
`````
rhel-7-server-satellite-tools-6.2-rpms                                                                                                                                                      | 2.1 kB  00:00:00
Package cockpit-shell is obsoleted by cockpit-system, trying to install cockpit-system-131-3.el7.noarch instead
Resolving Dependencies
--> Running transaction check
---> Package cockpit-bridge.x86_64 0:131-3.el7 will be installed
---> Package cockpit-docker.x86_64 0:131-3.el7 will be installed
---> Package cockpit-kubernetes.x86_64 0:135-4.el7 will be installed
---> Package cockpit-system.noarch 0:131-3.el7 will be installed
---> Package cockpit-ws.x86_64 0:131-3.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

Transaction check error:
  file /usr/libexec/cockpit-stub conflicts between attempted installs of cockpit-ws-131-3.el7.x86_64 and cockpit-kubernetes-135-4.el7.x86_64
`````

We should instead install package 'cockpit-system' to resolve this conflict issue and install correct package for cockpit.



